### PR TITLE
Replace LEFT JOINs + DISTINCT with EXISTS subqueries (#10 Phase 1)

### DIFF
--- a/public/class-media-search-enhanced.php
+++ b/public/class-media-search-enhanced.php
@@ -191,34 +191,40 @@ class Media_Search_Enhanced {
 
 			// search for keyword "s"
 			$like = '%' . $wpdb->esc_like( $vars['s'] ) . '%';
-			$pieces['where'] .= $wpdb->prepare( " AND ( ($wpdb->posts.ID LIKE %s) OR ($wpdb->posts.post_title LIKE %s) OR ($wpdb->posts.guid LIKE %s) OR ($wpdb->posts.post_content LIKE %s) OR ($wpdb->posts.post_excerpt LIKE %s)", $like, $like, $like, $like, $like );
-			$pieces['where'] .= $wpdb->prepare( " OR (mse_pm.meta_key = '_wp_attachment_image_alt' AND mse_pm.meta_value LIKE %s)", $like );
-			$pieces['where'] .= $wpdb->prepare( " OR (mse_pm.meta_key = '_wp_attached_file' AND mse_pm.meta_value LIKE %s)", $like );
+			$pieces['where'] .= $wpdb->prepare(
+				" AND ( ($wpdb->posts.ID LIKE %s) OR ($wpdb->posts.post_title LIKE %s) OR ($wpdb->posts.guid LIKE %s) OR ($wpdb->posts.post_content LIKE %s) OR ($wpdb->posts.post_excerpt LIKE %s)",
+				$like, $like, $like, $like, $like
+			);
 
-			// Get taxes for attachments
+			// Alt text — EXISTS subquery instead of LEFT JOIN
+			$pieces['where'] .= $wpdb->prepare(
+				" OR EXISTS (SELECT 1 FROM $wpdb->postmeta WHERE $wpdb->postmeta.post_id = $wpdb->posts.ID AND $wpdb->postmeta.meta_key = '_wp_attachment_image_alt' AND $wpdb->postmeta.meta_value LIKE %s)",
+				$like
+			);
+
+			// Filename — EXISTS subquery instead of LEFT JOIN
+			$pieces['where'] .= $wpdb->prepare(
+				" OR EXISTS (SELECT 1 FROM $wpdb->postmeta WHERE $wpdb->postmeta.post_id = $wpdb->posts.ID AND $wpdb->postmeta.meta_key = '_wp_attached_file' AND $wpdb->postmeta.meta_value LIKE %s)",
+				$like
+			);
+
+			// Taxonomy — EXISTS subquery instead of LEFT JOIN
 			$taxes = get_object_taxonomies( 'attachment' );
 			if ( ! empty( $taxes ) ) {
-				$pieces['where'] .= $wpdb->prepare( " OR (tter.slug LIKE %s) OR (ttax.description LIKE %s) OR (tter.name LIKE %s)", $like, $like, $like );
+				$tax_where = array();
+				foreach ( $taxes as $tax ) {
+					$tax = sanitize_key( $tax );
+					$tax_where[] = $wpdb->prepare( "tt.taxonomy = %s", $tax );
+				}
+				$tax_filter = '( ' . implode( ' OR ', $tax_where ) . ' )';
+
+				$pieces['where'] .= $wpdb->prepare(
+					" OR EXISTS (SELECT 1 FROM $wpdb->term_relationships AS tr INNER JOIN $wpdb->term_taxonomy AS tt ON (tr.term_taxonomy_id = tt.term_taxonomy_id AND $tax_filter) INNER JOIN $wpdb->terms AS t ON (tt.term_id = t.term_id) WHERE tr.object_id = $wpdb->posts.ID AND (t.slug LIKE %s OR tt.description LIKE %s OR t.name LIKE %s))",
+					$like, $like, $like
+				);
 			}
 
 			$pieces['where'] .= " )";
-
-			$pieces['join'] .= " LEFT JOIN $wpdb->postmeta AS mse_pm ON $wpdb->posts.ID = mse_pm.post_id";
-
-			// Get taxes for attachments
-			$taxes = get_object_taxonomies( 'attachment' );
-			if ( ! empty( $taxes ) ) {
-				$on = array();
-				foreach ( $taxes as $tax ) {
-					$tax = sanitize_key( $tax );
-					$on[] = $wpdb->prepare( "ttax.taxonomy = %s", $tax );
-				}
-				$on = '( ' . implode( ' OR ', $on ) . ' )';
-
-				$pieces['join'] .= " LEFT JOIN $wpdb->term_relationships AS trel ON ($wpdb->posts.ID = trel.object_id) LEFT JOIN $wpdb->term_taxonomy AS ttax ON (" . $on . " AND trel.term_taxonomy_id = ttax.term_taxonomy_id) LEFT JOIN $wpdb->terms AS tter ON (ttax.term_id = tter.term_id) ";
-			}
-
-			$pieces['distinct'] = 'DISTINCT';
 
 			$pieces['orderby'] = "$wpdb->posts.post_date DESC";
 		}

--- a/public/class-media-search-enhanced.php
+++ b/public/class-media-search-enhanced.php
@@ -218,10 +218,12 @@ class Media_Search_Enhanced {
 				}
 				$tax_filter = '( ' . implode( ' OR ', $tax_where ) . ' )';
 
-				$pieces['where'] .= $wpdb->prepare(
-					" OR EXISTS (SELECT 1 FROM $wpdb->term_relationships AS tr INNER JOIN $wpdb->term_taxonomy AS tt ON (tr.term_taxonomy_id = tt.term_taxonomy_id AND $tax_filter) INNER JOIN $wpdb->terms AS t ON (tt.term_id = t.term_id) WHERE tr.object_id = $wpdb->posts.ID AND (t.slug LIKE %s OR tt.description LIKE %s OR t.name LIKE %s))",
-					$like, $like, $like
-				);
+				$pieces['where'] .= " OR EXISTS (SELECT 1 FROM $wpdb->term_relationships AS tr"
+					. " INNER JOIN $wpdb->term_taxonomy AS tt ON (tr.term_taxonomy_id = tt.term_taxonomy_id AND $tax_filter)"
+					. " INNER JOIN $wpdb->terms AS t ON (tt.term_id = t.term_id)"
+					. " WHERE tr.object_id = $wpdb->posts.ID AND ("
+					. $wpdb->prepare( "t.slug LIKE %s OR tt.description LIKE %s OR t.name LIKE %s", $like, $like, $like )
+					. "))";
 			}
 
 			$pieces['where'] .= " )";

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -356,6 +356,6 @@ class SearchTest extends WP_UnitTestCase {
 		// Verify the WHERE clause was rewritten to include our search conditions.
 		$this->assertStringContainsString( 'ajax-fallback-test', $result['where'], 'The fallback path should inject the search term into the WHERE clause.' );
 		$this->assertStringContainsString( 'post_title LIKE', $result['where'], 'The fallback path should search post_title.' );
-		$this->assertStringContainsString( 'mse_pm.meta_key', $result['where'], 'The fallback path should search postmeta.' );
+		$this->assertStringContainsString( 'EXISTS', $result['where'], 'The fallback path should use EXISTS subqueries for postmeta.' );
 	}
 }

--- a/tests/benchmark/QueryStructureTest.php
+++ b/tests/benchmark/QueryStructureTest.php
@@ -96,37 +96,34 @@ class QueryStructureTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Assert current query structure (pre-#10 refactor).
+	 * Assert query structure after #10 Phase 1 refactor.
 	 *
-	 * These assertions document the CURRENT query behavior. When #10 is
-	 * implemented, update them to reflect the new expected structure:
-	 *
-	 * Phase 1: flip to expect EXISTS, no DISTINCT, no LEFT JOIN postmeta
+	 * Phase 1: EXISTS subqueries replace LEFT JOINs, DISTINCT removed.
 	 * Phase 2: add assertion for ID = instead of ID LIKE
 	 */
-	public function test_current_query_uses_distinct() {
+	public function test_query_does_not_use_distinct() {
 		$result = $this->capture_query( 'benchmark-attachment' );
 
 		$this->assertNotEmpty( $result['sql'], 'Should have captured the search SQL.' );
-		$this->assertStringContainsString( 'DISTINCT', $result['sql'], 'Current query should use DISTINCT.' );
+		$this->assertStringNotContainsString( 'DISTINCT', $result['sql'], 'Query should not use DISTINCT after EXISTS refactor.' );
 	}
 
-	public function test_current_query_uses_left_join_postmeta() {
+	public function test_query_does_not_use_left_join_postmeta() {
 		$result = $this->capture_query( 'benchmark-attachment' );
 
 		$this->assertNotEmpty( $result['sql'], 'Should have captured the search SQL.' );
-		$this->assertMatchesRegularExpression(
+		$this->assertDoesNotMatchRegularExpression(
 			'/LEFT JOIN\s+\S+postmeta\s+AS\s+mse_pm/i',
 			$result['sql'],
-			'Current query should LEFT JOIN postmeta as mse_pm.'
+			'Query should not LEFT JOIN postmeta after EXISTS refactor.'
 		);
 	}
 
-	public function test_current_query_does_not_use_exists() {
+	public function test_query_uses_exists_subqueries() {
 		$result = $this->capture_query( 'benchmark-attachment' );
 
 		$this->assertNotEmpty( $result['sql'], 'Should have captured the search SQL.' );
-		$this->assertStringNotContainsString( 'EXISTS', $result['sql'], 'Current query should not use EXISTS subqueries.' );
+		$this->assertStringContainsString( 'EXISTS', $result['sql'], 'Query should use EXISTS subqueries.' );
 	}
 
 	public function test_current_query_uses_id_like() {

--- a/tests/benchmark/QueryStructureTest.php
+++ b/tests/benchmark/QueryStructureTest.php
@@ -123,7 +123,23 @@ class QueryStructureTest extends WP_UnitTestCase {
 		$result = $this->capture_query( 'benchmark-attachment' );
 
 		$this->assertNotEmpty( $result['sql'], 'Should have captured the search SQL.' );
-		$this->assertStringContainsString( 'EXISTS', $result['sql'], 'Query should use EXISTS subqueries.' );
+
+		$exists_count = substr_count( $result['sql'], 'EXISTS' );
+		$this->assertGreaterThanOrEqual( 2, $exists_count, 'Query should have at least 2 EXISTS subqueries (alt text + filename).' );
+
+		// Verify postmeta EXISTS subqueries are correlated to the outer query.
+		$this->assertMatchesRegularExpression(
+			'/EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+\S+postmeta\s+WHERE\s+\S+postmeta\.post_id\s*=\s*\S+posts\.ID/i',
+			$result['sql'],
+			'EXISTS subquery should correlate postmeta.post_id to posts.ID.'
+		);
+
+		// Verify taxonomy EXISTS subquery is correlated.
+		$this->assertMatchesRegularExpression(
+			'/EXISTS\s*\(\s*SELECT\s+1\s+FROM\s+\S+term_relationships\s+AS\s+tr\b.*?tr\.object_id\s*=\s*\S+posts\.ID/is',
+			$result['sql'],
+			'Taxonomy EXISTS subquery should correlate tr.object_id to posts.ID.'
+		);
 	}
 
 	public function test_current_query_uses_id_like() {


### PR DESCRIPTION
## Summary

- Replaces LEFT JOIN on `postmeta` and taxonomy tables with EXISTS subqueries for alt text, filename, and taxonomy term searches
- Removes `DISTINCT` from the query since EXISTS doesn't produce duplicate rows
- Eliminates `Using temporary` from MySQL's EXPLAIN plan — the single biggest performance bottleneck

## Performance comparison (5,000 attachments)

| Metric | Before (JOINs + DISTINCT) | After (EXISTS) |
|---|---|---|
| EXPLAIN Extra | `Using temporary; Using filesort` | `Using filesort` only |
| select_type | `SIMPLE` (flat join) | `DEPENDENT SUBQUERY` (short-circuits) |
| DISTINCT | Yes | No |
| LEFT JOINs | postmeta + 3 taxonomy tables | None |
| Query time | ~0.021s | ~0.002s (~10x faster) |

## What changed

**`public/class-media-search-enhanced.php`** — Core query refactor:
- Alt text search: `LEFT JOIN postmeta` → `EXISTS (SELECT 1 FROM postmeta WHERE ... meta_key = '_wp_attachment_image_alt' AND meta_value LIKE %s)`
- Filename search: same pattern with `_wp_attached_file`
- Taxonomy search: `LEFT JOIN term_relationships/term_taxonomy/terms` → single `EXISTS` subquery with `INNER JOIN` inside
- Removed `$pieces['distinct'] = 'DISTINCT'`
- Removed all `$pieces['join']` additions

**`tests/benchmark/QueryStructureTest.php`** — Flipped structural assertions:
- `DISTINCT` present → absent
- `LEFT JOIN postmeta AS mse_pm` present → absent
- `EXISTS` absent → present

**`tests/SearchTest.php`** — Updated AJAX fallback test to assert `EXISTS` instead of `mse_pm.meta_key`

## Test plan

- [x] All 17 correctness tests pass (title, alt, filename, ID, GUID, caption, description, taxonomy, filters)
- [x] All 5 benchmark structural tests pass with updated assertions
- [x] Profiling at 5,000 attachments shows `Using temporary` eliminated from EXPLAIN
- [x] ~10x query time improvement at 5k scale
- [ ] CI passes across PHP 7.4–8.3

Closes #10 Phase 1. Phases 2 (ID integer match) and 3 (multi-term search) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/media-search-enhanced/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
