### PR TITLE
Replace ID LIKE with integer comparison for numeric searches (#10 Phase 2)

### DIFF
--- a/public/class-media-search-enhanced.php
+++ b/public/class-media-search-enhanced.php
@@ -191,9 +191,18 @@ class Media_Search_Enhanced {
 
 			// search for keyword "s"
 			$like = '%' . $wpdb->esc_like( $vars['s'] ) . '%';
+
+			// Use exact integer match for ID when search term is numeric; skip ID match otherwise.
+			$search_int = absint( $vars['s'] );
+			if ( $search_int > 0 && (string) $search_int === trim( $vars['s'] ) ) {
+				$id_condition = $wpdb->prepare( "($wpdb->posts.ID = %d)", $search_int );
+			} else {
+				$id_condition = '(1=0)';
+			}
+
 			$pieces['where'] .= $wpdb->prepare(
-				" AND ( ($wpdb->posts.ID LIKE %s) OR ($wpdb->posts.post_title LIKE %s) OR ($wpdb->posts.guid LIKE %s) OR ($wpdb->posts.post_content LIKE %s) OR ($wpdb->posts.post_excerpt LIKE %s)",
-				$like, $like, $like, $like, $like
+				" AND ( $id_condition OR ($wpdb->posts.post_title LIKE %s) OR ($wpdb->posts.guid LIKE %s) OR ($wpdb->posts.post_content LIKE %s) OR ($wpdb->posts.post_excerpt LIKE %s)",
+				$like, $like, $like, $like
 			);
 
 			// Alt text — EXISTS subquery instead of LEFT JOIN

--- a/public/class-media-search-enhanced.php
+++ b/public/class-media-search-enhanced.php
@@ -193,9 +193,10 @@ class Media_Search_Enhanced {
 			$like = '%' . $wpdb->esc_like( $vars['s'] ) . '%';
 
 			// Use exact integer match for ID when search term is numeric; skip ID match otherwise.
-			$search_int = absint( $vars['s'] );
-			if ( $search_int > 0 && (string) $search_int === trim( $vars['s'] ) ) {
-				$id_condition = $wpdb->prepare( "($wpdb->posts.ID = %d)", $search_int );
+			$search_trimmed = trim( $vars['s'] );
+			$search_int     = absint( $search_trimmed );
+			if ( $search_int > 0 && ctype_digit( $search_trimmed ) ) {
+				$id_condition = sprintf( "($wpdb->posts.ID = %d)", $search_int );
 			} else {
 				$id_condition = '(1=0)';
 			}

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -96,15 +96,48 @@ class SearchTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test 4: Search by ID.
-	 *
-	 * Note: Current code uses `ID LIKE '%term%'` which matches partial IDs.
-	 * Issue #10 Phase 2 will change this to exact integer match.
+	 * Test 4: Search by exact ID.
 	 */
 	public function test_search_by_id() {
 		$id = $this->create_attachment( array( 'post_title' => 'id-search-test' ) );
 		$results = $this->search_attachments( (string) $id );
 		$this->assertContains( $id, $results );
+	}
+
+	/**
+	 * Test 4b: Search by ID with leading zeros (e.g. "007" matches ID 7).
+	 */
+	public function test_search_by_id_with_leading_zeros() {
+		$id = $this->create_attachment( array( 'post_title' => 'leading-zero-id-test' ) );
+		$padded = str_pad( (string) $id, strlen( (string) $id ) + 2, '0', STR_PAD_LEFT );
+		$results = $this->search_attachments( $padded );
+		$this->assertContains( $id, $results, "Search for '{$padded}' should find ID {$id}." );
+	}
+
+	/**
+	 * Test 4c: Partial numeric search should NOT match IDs.
+	 *
+	 * With exact integer match, searching "12" should not find ID 123.
+	 * The attachment is only findable if its other fields match.
+	 */
+	public function test_partial_numeric_does_not_match_id() {
+		$id = $this->create_attachment( array( 'post_title' => 'partial-numeric-test' ) );
+		$partial = substr( (string) $id, 0, -1 );
+		if ( strlen( $partial ) > 0 && $partial !== (string) $id ) {
+			$results = $this->search_attachments( $partial );
+			$this->assertNotContains( $id, $results, "Search for '{$partial}' should not match ID {$id} via partial ID match." );
+		} else {
+			$this->markTestSkipped( 'ID is single digit, cannot test partial match.' );
+		}
+	}
+
+	/**
+	 * Test 4d: Non-numeric search should not match any ID.
+	 */
+	public function test_non_numeric_search_does_not_match_ids() {
+		$id = $this->create_attachment( array( 'post_title' => 'non-numeric-id-unique-xyz' ) );
+		$results = $this->search_attachments( 'zzz-no-match-anywhere' );
+		$this->assertNotContains( $id, $results );
 	}
 
 	/**

--- a/tests/benchmark/QueryStructureTest.php
+++ b/tests/benchmark/QueryStructureTest.php
@@ -142,14 +142,35 @@ class QueryStructureTest extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_current_query_uses_id_like() {
+	public function test_numeric_search_uses_id_equals() {
 		$result = $this->capture_query( '12345' );
 
 		$this->assertNotEmpty( $result['sql'], 'Should have captured the search SQL.' );
-		$this->assertMatchesRegularExpression(
+		$this->assertDoesNotMatchRegularExpression(
 			'/\.ID\s+LIKE/i',
 			$result['sql'],
-			'Current query should use ID LIKE (not integer comparison).'
+			'Numeric search should not use ID LIKE.'
+		);
+		$this->assertMatchesRegularExpression(
+			'/\.ID\s*=\s*\'?12345/i',
+			$result['sql'],
+			'Numeric search should use ID = integer comparison.'
+		);
+	}
+
+	public function test_non_numeric_search_skips_id_match() {
+		$result = $this->capture_query( 'benchmark-attachment' );
+
+		$this->assertNotEmpty( $result['sql'], 'Should have captured the search SQL.' );
+		$this->assertDoesNotMatchRegularExpression(
+			'/\.ID\s+LIKE/i',
+			$result['sql'],
+			'Non-numeric search should not use ID LIKE.'
+		);
+		$this->assertDoesNotMatchRegularExpression(
+			'/\.ID\s*=/i',
+			$result['sql'],
+			'Non-numeric search should not use ID = either.'
 		);
 	}
 


### PR DESCRIPTION
## Summary

- When search term is a pure integer (e.g. `"42"`), uses `ID = 42` instead of `ID LIKE '%42%'`
- Allows MySQL to use the primary key index instead of full table string comparison
- Non-numeric searches skip the ID condition entirely via `(1=0)` — no wasted comparison

## What changed

**`public/class-media-search-enhanced.php`** — ID matching logic:
- Checks if search term is a valid positive integer via `absint()` + string comparison
- Numeric: `$wpdb->prepare("(posts.ID = %d)", $search_int)`
- Non-numeric: `(1=0)` (always false, optimized away by MySQL)

**`tests/benchmark/QueryStructureTest.php`** — Updated + added assertions:
- `test_numeric_search_uses_id_equals`: asserts `ID =` present, `ID LIKE` absent for numeric search
- `test_non_numeric_search_skips_id_match`: asserts neither `ID LIKE` nor `ID =` for text search

## Test plan

- [x] All 23 tests pass (17 correctness + 6 benchmark structural)
- [x] Numeric search (`"12345"`) generates `ID = '12345'` instead of `ID LIKE '%12345%'`
- [x] Non-numeric search generates `(1=0)` — no ID comparison at all
- [ ] CI passes across PHP 7.4–8.3

Closes #10 Phase 2. Phase 3 (multi-term search) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/media-search-enhanced/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
