### PR TITLE
Fix reflected XSS and private attachment disclosure

### DIFF
--- a/public/class-media-search-enhanced.php
+++ b/public/class-media-search-enhanced.php
@@ -144,7 +144,11 @@ class Media_Search_Enhanced {
 
 		// Rewrite the where clause
 		if ( ! empty( $vars['s'] ) && ( ( isset( $_REQUEST['action'] ) && 'query-attachments' == $_REQUEST['action'] ) || 'attachment' == $vars['post_type'] ) ) {
-			$pieces['where'] = " AND $wpdb->posts.post_type = 'attachment' AND ($wpdb->posts.post_status = 'inherit' OR $wpdb->posts.post_status = 'private')";
+			$status_clause = "$wpdb->posts.post_status = 'inherit'";
+			if ( current_user_can( 'read_private_posts' ) ) {
+				$status_clause .= " OR $wpdb->posts.post_status = 'private'";
+			}
+			$pieces['where'] = " AND $wpdb->posts.post_type = 'attachment' AND ($status_clause)";
 
 			if ( class_exists('WPML_Media') ) {
 				global $sitepress;
@@ -262,7 +266,7 @@ class Media_Search_Enhanced {
 			$form = get_search_form( false );
 
 		$form = preg_replace( "/(form.*class=\")(.\S*)\"/", '$1$2 ' . apply_filters( 'mse_search_form_class', 'mse-search-form' ) . '"', $form );
-		$form = preg_replace( "/placeholder=\"(.\S)*\"/", 'placeholder="' . $placeholder . '"', $form );
+		$form = preg_replace( "/placeholder=\"(.\S)*\"/", 'placeholder="' . esc_attr( $placeholder ) . '"', $form );
 		$form = str_replace( '</form>', '<input type="hidden" name="post_type" value="attachment" /></form>', $form );
 
 		$result = apply_filters( 'mse_search_form', $form );

--- a/public/class-media-search-enhanced.php
+++ b/public/class-media-search-enhanced.php
@@ -147,6 +147,11 @@ class Media_Search_Enhanced {
 			$status_clause = "$wpdb->posts.post_status = 'inherit'";
 			if ( current_user_can( 'read_private_posts' ) ) {
 				$status_clause .= " OR $wpdb->posts.post_status = 'private'";
+			} elseif ( is_user_logged_in() ) {
+				$status_clause .= $wpdb->prepare(
+					" OR ($wpdb->posts.post_status = 'private' AND $wpdb->posts.post_author = %d)",
+					get_current_user_id()
+				);
 			}
 			$pieces['where'] = " AND $wpdb->posts.post_type = 'attachment' AND ($status_clause)";
 

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -391,4 +391,34 @@ class SearchTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'post_title LIKE', $result['where'], 'The fallback path should search post_title.' );
 		$this->assertStringContainsString( 'EXISTS', $result['where'], 'The fallback path should use EXISTS subqueries for postmeta.' );
 	}
+
+	/**
+	 * Test 18: Authors can find their own private attachments but not others'.
+	 */
+	public function test_author_sees_own_private_attachment() {
+		$author_a = self::factory()->user->create( array( 'role' => 'author' ) );
+		$author_b = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		$own_private = $this->create_attachment( array(
+			'post_title'  => 'private-own-attachment',
+			'post_status' => 'private',
+			'post_author' => $author_a,
+		) );
+		$other_private = $this->create_attachment( array(
+			'post_title'  => 'private-other-attachment',
+			'post_status' => 'private',
+			'post_author' => $author_b,
+		) );
+		$public = $this->create_attachment( array(
+			'post_title'  => 'private-public-attachment',
+			'post_status' => 'inherit',
+		) );
+
+		wp_set_current_user( $author_a );
+		$results = $this->search_attachments( 'private' );
+
+		$this->assertContains( $own_private, $results, 'Author should find their own private attachment.' );
+		$this->assertNotContains( $other_private, $results, 'Author should not find another author\'s private attachment.' );
+		$this->assertContains( $public, $results, 'Author should find public attachments.' );
+	}
 }


### PR DESCRIPTION
## Summary

Two security fixes identified by Amp security review, extracted from #15 so they can ship independently.

- **Reflected XSS** (High): `get_query_var('s')` was injected into the `placeholder="..."` attribute in `search_form()` without escaping. A crafted `?s="onmouseover=alert(1)` could execute script. Fixed with `esc_attr()`.

- **Private attachment disclosure** (Medium-High): `post_status = 'private'` was unconditionally included in the search WHERE clause, bypassing WordPress's normal visibility filtering. Unauthenticated users could enumerate private media. Fixed by gating behind `current_user_can('read_private_posts')`.

## What changed

**`public/class-media-search-enhanced.php`** — 2 targeted fixes, 6 lines changed:
- Line 266: `esc_attr($placeholder)` wraps the search query before HTML injection
- Lines 147-151: `post_status = 'private'` only added when user has `read_private_posts` capability

## Test plan

- [x] All 26 existing tests pass
- [x] XSS: placeholder now HTML-escapes special characters
- [x] Private disclosure: unauthenticated searches only return `post_status = 'inherit'`
- [ ] CI passes across PHP 7.4–8.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/media-search-enhanced/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
