### PR TITLE
Surface Playground demo link on wordpress.org listing

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,6 +13,8 @@ Search through all fields in Media Library.
 
 == Description ==
 
+**Try it live in your browser** — [launch the WordPress Playground demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/1fixdotio/media-search-enhanced/master/blueprint/playground.blueprint.json). Boots a WordPress instance with this plugin active and a Media Library seeded with 8 attachments, so you can see the cross-field search in action immediately. Searching `mountain` returns 6 hits (matches in filename and alt text included) — core WordPress search would only find 3.
+
 This plugin is made for:
 
 * Search through all fields in Media Library, including: ID, title, caption, alternative text and description.


### PR DESCRIPTION
## Summary

Adds a "Try it live in your browser" pointer to the top of \`README.txt\`'s Description section so the Playground demo is visible on the wordpress.org plugin page (not only on GitHub).

- One-line insertion — no structural changes.
- Uses \`[text](url)\` markdown, which the wordpress.org readme parser renders as an anchor.
- Calls out the concrete proof point (6 hits vs core's 3) so visitors know what the demo shows before clicking.

## Why land this before v1.0.0

\`deploy.yml\` only runs on released GitHub releases. Merging this to master now means the \`README.txt\` update ships alongside the v1.0.0 plugin code in the same SVN push — no wasted point release.

## Test plan

- [x] Diff is one-line insertion.
- [ ] Reviewer: confirm the anchor renders correctly on wordpress.org once the 1.0.0 release ships (readme parser is slightly different from GitHub's markdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/media-search-enhanced/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
