### PR TITLE
Widen multi-term search scope to the entire WordPress admin

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -20,7 +20,7 @@ This plugin is made for:
 * Search through all fields in Media Library, including: ID, title, caption, alternative text and description.
 * Search Taxonomies for Media, include the name, slug and description fields.
 * Search media file name.
-* **Multi-term search** — In the admin Media Library modal, use commas to search for multiple items at once (e.g. `image-a.jpg, photo-2.jpg`). Matches attachments containing **any** of the terms. Limited to 10 terms per search. This feature is only available in the admin media modal; frontend searches treat commas as literal characters.
+* **Multi-term search** — Anywhere in the WordPress admin (the Media Library list view at `upload.php`, the "Add Media" modal, and other admin screens), use commas to search for multiple items at once (e.g. `image-a.jpg, photo-2.jpg`). Matches attachments containing **any** of the terms. Limited to 10 terms per search. Frontend searches still treat commas as literal characters, as a query-amplification guard for public pages.
 * Use shortcode `[mse-search-form]` to insert a media search form in posts and template files. It will search for media by all fields mentioned above.
 
 == Installation ==
@@ -69,13 +69,13 @@ Please add the following code to the `functions.php` in your theme:
 == Changelog ==
 
 = 1.0.0 =
-* New: Multi-term search — use commas to search for multiple items at once in the admin media modal (e.g. `sunset.jpg, logo.png`). Limited to 10 terms. Only available in the admin media modal; frontend searches treat commas as literal characters.
+* New: Multi-term search — use commas to search for multiple items at once anywhere in wp-admin, including the Media Library list view and the "Add Media" modal (e.g. `sunset.jpg, logo.png`). Limited to 10 terms. Frontend searches still treat commas as literal characters.
 * Performance: Replaced LEFT JOINs + DISTINCT with EXISTS subqueries, eliminating temporary tables and improving search speed up to 10x on large media libraries.
 * Performance: Numeric searches (e.g. searching by attachment ID) now use exact integer matching instead of string comparison, enabling primary key index usage.
 * Compatibility: The plugin no longer overwrites the entire WHERE clause. Conditions from WordPress core and other plugins are now preserved.
 * Security: Fixed reflected XSS in the search form placeholder.
 * Security: Private attachments are now only visible to users with appropriate permissions (editors/admins see all; authors see only their own).
-* Developer: Added `mse_max_search_terms` filter to customize the multi-term cap (default 10). Added `mse_is_media_modal_request` filter to customize where multi-term search is allowed.
+* Developer: Added `mse_max_search_terms` filter to customize the multi-term cap (default 10). Added `mse_allow_multi_term_search` filter to customize where multi-term search is allowed; defaults to `is_admin()`.
 
 = 0.9.2 =
 * Security enhancements.

--- a/public/class-media-search-enhanced.php
+++ b/public/class-media-search-enhanced.php
@@ -216,13 +216,12 @@ class Media_Search_Enhanced {
 			$pieces['where'] .= $wpdb->prepare( " AND t.element_type='post_attachment' AND t.language_code = %s", $lang );
 		}
 
-		// Multi-term (comma-separated) search is restricted to the admin media
-		// modal to prevent query amplification on public-facing search pages.
-		$is_media_modal = is_admin() && defined( 'DOING_AJAX' ) && DOING_AJAX
-			&& isset( $_REQUEST['action'] ) && 'query-attachments' === $_REQUEST['action'];
-		$is_media_modal = apply_filters( 'mse_is_media_modal_request', $is_media_modal );
-		$max_terms      = (int) apply_filters( 'mse_max_search_terms', 10 );
-		if ( $is_media_modal && strpos( $vars['s'], ',' ) !== false ) {
+		// Multi-term (comma-separated) search is limited to wp-admin; admin users are
+		// authenticated, so the frontend query-amplification concern does not apply.
+		$allow_multi_term = is_admin();
+		$allow_multi_term = apply_filters( 'mse_allow_multi_term_search', $allow_multi_term );
+		$max_terms        = (int) apply_filters( 'mse_max_search_terms', 10 );
+		if ( $allow_multi_term && strpos( $vars['s'], ',' ) !== false ) {
 			$terms = array_values( array_filter( array_map( 'trim', explode( ',', $vars['s'] ) ), 'strlen' ) );
 		} else {
 			$terms = array( $vars['s'] );

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -379,7 +379,7 @@ class SearchTest extends WP_UnitTestCase {
 		$id = $this->create_attachment( array( 'post_title' => 'ajax-fallback-test' ) );
 
 		// Simulate the AJAX media modal request.
-		add_filter( 'mse_is_media_modal_request', '__return_true' );
+		add_filter( 'mse_allow_multi_term_search', '__return_true' );
 		$_REQUEST['query']  = array(
 			's'         => 'ajax-fallback-test',
 			'post_type' => 'attachment',
@@ -446,10 +446,10 @@ class SearchTest extends WP_UnitTestCase {
 
 	/**
 	 * Test 19: Comma-separated search finds attachments matching ANY term.
-	 * Multi-term search is restricted to the admin media modal context.
+	 * Multi-term search is gated to the WordPress admin; the filter forces it on here.
 	 */
 	public function test_comma_separated_search() {
-		add_filter( 'mse_is_media_modal_request', '__return_true' );
+		add_filter( 'mse_allow_multi_term_search', '__return_true' );
 
 		$id_a = $this->create_attachment( array( 'post_title' => 'alpha-comma-test' ) );
 		$id_b = $this->create_attachment( array( 'post_title' => 'bravo-comma-test' ) );
@@ -458,12 +458,38 @@ class SearchTest extends WP_UnitTestCase {
 		try {
 			$results = $this->search_attachments( 'alpha-comma-test, bravo-comma-test' );
 		} finally {
-			remove_filter( 'mse_is_media_modal_request', '__return_true' );
+			remove_filter( 'mse_allow_multi_term_search', '__return_true' );
 		}
 
 		$this->assertContains( $id_a, $results, 'Should find attachment matching first term.' );
 		$this->assertContains( $id_b, $results, 'Should find attachment matching second term.' );
 		$this->assertNotContains( $id_c, $results, 'Should not find attachment matching neither term.' );
+	}
+
+	/**
+	 * Test 19b: Default admin context enables multi-term search without any filter.
+	 *
+	 * Proves that `is_admin() === true` is sufficient to trigger the comma split —
+	 * no `mse_allow_multi_term_search` override required. This is the behaviour
+	 * the Media Library list view (`upload.php`) and other admin screens rely on.
+	 */
+	public function test_comma_separated_search_in_admin_by_default() {
+		set_current_screen( 'upload.php' );
+
+		$id_a = $this->create_attachment( array( 'post_title' => 'admin-default-alpha' ) );
+		$id_b = $this->create_attachment( array( 'post_title' => 'admin-default-bravo' ) );
+		$id_c = $this->create_attachment( array( 'post_title' => 'admin-default-charlie-no-match' ) );
+
+		try {
+			$this->assertTrue( is_admin(), 'set_current_screen() should flip is_admin() to true.' );
+			$results = $this->search_attachments( 'admin-default-alpha, admin-default-bravo' );
+		} finally {
+			set_current_screen( 'front' );
+		}
+
+		$this->assertContains( $id_a, $results, 'Admin default should match first term.' );
+		$this->assertContains( $id_b, $results, 'Admin default should match second term.' );
+		$this->assertNotContains( $id_c, $results, 'Admin default should not match unrelated attachment.' );
 	}
 
 	/**
@@ -483,7 +509,7 @@ class SearchTest extends WP_UnitTestCase {
 	 * Test 20: Comma-separated search across different fields.
 	 */
 	public function test_comma_search_across_fields() {
-		add_filter( 'mse_is_media_modal_request', '__return_true' );
+		add_filter( 'mse_allow_multi_term_search', '__return_true' );
 
 		$id_by_title = $this->create_attachment( array( 'post_title' => 'multi-field-title-match' ) );
 		$id_by_alt   = $this->create_attachment( array( 'post_title' => 'unrelated-alt-holder' ) );
@@ -492,7 +518,7 @@ class SearchTest extends WP_UnitTestCase {
 		try {
 			$results = $this->search_attachments( 'multi-field-title-match, multi-field-alt-match' );
 		} finally {
-			remove_filter( 'mse_is_media_modal_request', '__return_true' );
+			remove_filter( 'mse_allow_multi_term_search', '__return_true' );
 		}
 
 		$this->assertContains( $id_by_title, $results, 'Should find attachment matching by title.' );
@@ -503,14 +529,14 @@ class SearchTest extends WP_UnitTestCase {
 	 * Test 21: Empty terms from extra commas are ignored.
 	 */
 	public function test_comma_search_ignores_empty_terms() {
-		add_filter( 'mse_is_media_modal_request', '__return_true' );
+		add_filter( 'mse_allow_multi_term_search', '__return_true' );
 
 		$id = $this->create_attachment( array( 'post_title' => 'empty-comma-test' ) );
 
 		try {
 			$results = $this->search_attachments( ',, empty-comma-test ,,' );
 		} finally {
-			remove_filter( 'mse_is_media_modal_request', '__return_true' );
+			remove_filter( 'mse_allow_multi_term_search', '__return_true' );
 		}
 
 		$this->assertContains( $id, $results, 'Should find attachment despite extra commas.' );
@@ -520,7 +546,8 @@ class SearchTest extends WP_UnitTestCase {
 	 * Test 21b: Frontend search treats commas literally (no splitting).
 	 */
 	public function test_frontend_comma_search_is_literal() {
-		// No $_REQUEST['action'] = 'query-attachments' — simulates frontend search.
+		// No admin context in this test run, so is_admin() is false and the
+		// multi-term gate stays closed — the comma is matched literally.
 		$id_a = $this->create_attachment( array( 'post_title' => 'frontend-alpha-test' ) );
 		$id_b = $this->create_attachment( array( 'post_title' => 'frontend-bravo-test' ) );
 
@@ -534,14 +561,14 @@ class SearchTest extends WP_UnitTestCase {
 	 * Must be authenticated to exercise the comma-splitting + empty guard path.
 	 */
 	public function test_all_commas_search_returns_empty() {
-		add_filter( 'mse_is_media_modal_request', '__return_true' );
+		add_filter( 'mse_allow_multi_term_search', '__return_true' );
 
 		$id = $this->create_attachment( array( 'post_title' => 'should-not-appear' ) );
 
 		try {
 			$results = $this->search_attachments( ',,,' );
 		} finally {
-			remove_filter( 'mse_is_media_modal_request', '__return_true' );
+			remove_filter( 'mse_allow_multi_term_search', '__return_true' );
 		}
 
 		$this->assertEmpty( $results, 'Search with only commas should return no results.' );
@@ -551,7 +578,7 @@ class SearchTest extends WP_UnitTestCase {
 	 * Test 22: Terms are capped at 10.
 	 */
 	public function test_comma_search_caps_at_10_terms() {
-		add_filter( 'mse_is_media_modal_request', '__return_true' );
+		add_filter( 'mse_allow_multi_term_search', '__return_true' );
 
 		// Use non-overlapping names (alpha, bravo, etc.) to avoid LIKE substring matches.
 		$names = array( 'alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'golf', 'hotel', 'india', 'juliet', 'kilo', 'lima' );
@@ -565,7 +592,7 @@ class SearchTest extends WP_UnitTestCase {
 		try {
 			$results = $this->search_attachments( $search, array( 'posts_per_page' => -1 ) );
 		} finally {
-			remove_filter( 'mse_is_media_modal_request', '__return_true' );
+			remove_filter( 'mse_allow_multi_term_search', '__return_true' );
 		}
 
 		// First 10 terms should match.

--- a/tests/benchmark/QueryStructureTest.php
+++ b/tests/benchmark/QueryStructureTest.php
@@ -179,11 +179,11 @@ class QueryStructureTest extends WP_UnitTestCase {
 	 * Assert multi-term (comma-separated) search generates OR groups.
 	 */
 	public function test_multi_term_search_generates_or_groups() {
-		add_filter( 'mse_is_media_modal_request', '__return_true' );
+		add_filter( 'mse_allow_multi_term_search', '__return_true' );
 
 		$result = $this->capture_query( 'alpha-term, beta-term' );
 
-		remove_filter( 'mse_is_media_modal_request', '__return_true' );
+		remove_filter( 'mse_allow_multi_term_search', '__return_true' );
 
 		$this->assertNotEmpty( $result['sql'], 'Should have captured the search SQL.' );
 


### PR DESCRIPTION
## Summary
- Default gate for comma-separated multi-term attachment search is now `is_admin()` instead of the admin-ajax-only `query-attachments` check, so the feature also fires on the Media Library list view (`upload.php`) and anywhere else in wp-admin.
- Frontend behavior is unchanged: commas are still matched literally on public pages as a query-amplification guard.
- Developer filter renamed: `mse_is_media_modal_request` -> `mse_allow_multi_term_search`. Because v1.0.0 has not shipped (no tag, no .org release), this rename has no external consumers and avoids carrying a deprecated alias.
- README.txt description bullet and 1.0.0 changelog entries updated to reflect the widened scope and the new filter name.

## Test plan
- [x] `composer test` passes locally (36 tests, 83 assertions) including the new `test_comma_separated_search_in_admin_by_default`.
- [x] `test_frontend_comma_search_is_literal` still passes, proving frontend commas remain literal.
- [x] All existing multi-term tests (comma search, cross-field, empty terms, all-commas, cap-at-10) still pass under the renamed filter.
- [ ] Manual: on a dev WordPress install, search `forest, alpine` on `upload.php` and confirm both are matched.
- [ ] Manual: on a dev WordPress install, search `forest, alpine` in a frontend `[mse-search-form]` and confirm the comma is literal (no split).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/media-search-enhanced/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
