### PR TITLE
Clarify bump-release placeholder in blueprint/README.md

### DIFF
--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -66,13 +66,13 @@ The script rewrites the `raw.githubusercontent.com/.../<ref>/blueprint/...` URLs
 
 ## Bumping the pinned release
 
-`pluginData` points at the release zip built by `.github/workflows/deploy.yml` (via `10up/action-wordpress-plugin-deploy`). When you publish a new release (e.g. `1.1.0`), update the URL in `playground.blueprint.json`:
+`pluginData` points at the release zip built by `.github/workflows/deploy.yml` (via `10up/action-wordpress-plugin-deploy`). Current pin: `1.0.0`. When you publish a new release, update the version segment in `playground.blueprint.json`:
 
 ```json
 "pluginData": {
   "resource": "url",
-  "url": "https://github.com/1fixdotio/media-search-enhanced/releases/download/1.1.0/media-search-enhanced.zip"
+  "url": "https://github.com/1fixdotio/media-search-enhanced/releases/download/<NEW_VERSION>/media-search-enhanced.zip"
 }
 ```
 
-Only the version segment changes. The zip is always named `media-search-enhanced.zip` and is attached to the release automatically by the deploy workflow.
+Replace `<NEW_VERSION>` with the release tag (e.g. `1.0.1`, `1.1.0`). Only the version segment changes — the zip is always named `media-search-enhanced.zip` and is attached to the release automatically by the deploy workflow.


### PR DESCRIPTION
## Summary

The "Bumping the pinned release" section in \`blueprint/README.md\` used \`1.1.0\` directly in the JSON example URL, which can read like a real (broken) release link. Swapped to a \`<NEW_VERSION>\` placeholder and called out the current pinned version (1.0.0) explicitly so readers aren't confused.

No functional change — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/media-search-enhanced/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
