### PR TITLE
Add configurable search fields for large media libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ bash bin/install-wp-tests.sh <db-name> <db-user> <db-pass> [db-host] [wp-version
 
 CI runs `composer test` on every push/PR across PHP 7.4-8.3 with MySQL 8.0.
 
+## Large-library tuning
+
+Large media libraries can trim the search surface area without changing the default plugin behavior. Use the `mse_search_fields` filter to disable the most expensive clauses you do not need, such as `guid` or `taxonomy`.
+
+```php
+add_filter( 'mse_search_fields', function( $fields, $query, $terms ) {
+	$fields['guid'] = false;
+	$fields['taxonomy'] = false;
+	return $fields;
+}, 10, 3 );
+```
+
+Supported keys are `id`, `title`, `guid`, `description`, `caption`, `alt_text`, `filename`, and `taxonomy`. Unspecified keys keep their defaults. If you disable every field, the query returns no results.
+
 ## Validating SQL performance changes
 
 When working on query changes (e.g., [#10](https://github.com/1fixdotio/media-search-enhanced/issues/10)), use these three layers to validate correctness and performance.

--- a/README.txt
+++ b/README.txt
@@ -61,6 +61,21 @@ Please add the following code to the `functions.php` in your theme:
 	}
 	add_filter( 'mse_get_attachment_url', 'my_get_attachment_url', 10, 2 );
 
+= How do I tune the plugin for a very large media library? =
+
+Use the `mse_search_fields` filter to disable expensive search clauses you do not need, such as `guid` or `taxonomy`.
+
+	add_filter( 'mse_search_fields', 'my_mse_search_fields', 10, 3 );
+	function my_mse_search_fields( $fields, $query, $terms ) {
+		$fields['guid'] = false;
+		$fields['taxonomy'] = false;
+		return $fields;
+	}
+
+Supported keys are `id`, `title`, `guid`, `description`, `caption`, `alt_text`, `filename`, and `taxonomy`.
+
+Return strict booleans for the keys you change. Unspecified keys keep their default values. If you disable every search field, the query will return no results.
+
 == Screenshots ==
 
 1. Demo search on the Media Library screen.

--- a/README.txt
+++ b/README.txt
@@ -74,7 +74,7 @@ Use the `mse_search_fields` filter to disable expensive search clauses you do no
 
 Supported keys are `id`, `title`, `guid`, `description`, `caption`, `alt_text`, `filename`, and `taxonomy`.
 
-Return strict booleans for the keys you change. Unspecified keys keep their default values. If you disable every search field, the query will return no results.
+Return truthy or falsy values for the keys you change. Unspecified keys keep their default values. If you disable every search field, the query will return no results.
 
 == Screenshots ==
 

--- a/public/class-media-search-enhanced.php
+++ b/public/class-media-search-enhanced.php
@@ -163,9 +163,9 @@ class Media_Search_Enhanced {
 	/**
 	 * Append expanded search conditions to the SQL WHERE clause.
 	 *
-	 * Instead of overwriting $pieces['where'], this preserves conditions
-	 * from WordPress core and other plugins (type, status, date, parent,
-	 * mime, author restrictions, etc.) and only appends the search logic.
+	 * Instead of overwriting $pieces['where'], this preserves non-search
+	 * conditions from WordPress core and other plugins (type, status, date,
+	 * parent, mime, author restrictions, etc.) and only appends the search logic.
 	 *
 	 * Core's default search clause is suppressed by suppress_core_search()
 	 * to prevent conflicts with our expanded conditions.
@@ -232,8 +232,30 @@ class Media_Search_Enhanced {
 		}
 		$terms = array_slice( $terms, 0, max( 1, $max_terms ) );
 
+		// Large sites can narrow the query surface area without changing the default behavior.
+		$search_fields = array(
+			'id'          => true,
+			'title'       => true,
+			'guid'        => true,
+			'description' => true,
+			'caption'     => true,
+			'alt_text'    => true,
+			'filename'    => true,
+			'taxonomy'    => true,
+		);
+		// Callbacks can return either the full field map or only the keys they want to change.
+		$search_fields = array_intersect_key(
+			array_merge( $search_fields, (array) apply_filters( 'mse_search_fields', $search_fields, $query, $terms ) ),
+			$search_fields
+		);
+
+		if ( empty( array_filter( $search_fields ) ) ) {
+			$pieces['where'] .= " AND 1=0";
+			return $pieces;
+		}
+
 		// Build taxonomy filter once (shared across all terms).
-		$taxes      = get_object_taxonomies( 'attachment' );
+		$taxes      = $search_fields['taxonomy'] ? get_object_taxonomies( 'attachment' ) : array();
 		$tax_filter = '';
 		if ( ! empty( $taxes ) ) {
 			$tax_where = array();
@@ -247,7 +269,7 @@ class Media_Search_Enhanced {
 		// Generate search conditions for each term, then OR them together.
 		$term_groups = array();
 		foreach ( $terms as $term ) {
-			$term_groups[] = self::build_search_conditions( $term, $taxes, $tax_filter );
+			$term_groups[] = self::build_search_conditions( $term, $taxes, $tax_filter, $search_fields );
 		}
 
 		$pieces['where'] .= " AND ( " . implode( ' OR ', $term_groups ) . " )";
@@ -265,40 +287,56 @@ class Media_Search_Enhanced {
 	 * @param string $tax_filter Pre-built taxonomy filter clause.
 	 * @return string SQL fragment: ( id_cond OR title LIKE ... OR EXISTS ... )
 	 */
-	private static function build_search_conditions( $term, $taxes, $tax_filter ) {
+	private static function build_search_conditions( $term, $taxes, $tax_filter, $search_fields ) {
 		global $wpdb;
 
 		$like = '%' . $wpdb->esc_like( $term ) . '%';
+		$conditions = array();
 
 		// Use exact integer match for ID when search term is numeric.
-		$search_trimmed = trim( $term );
-		$search_int     = absint( $search_trimmed );
-		if ( $search_int > 0 && ctype_digit( $search_trimmed ) ) {
-			$id_condition = sprintf( "($wpdb->posts.ID = %d)", $search_int );
-		} else {
-			$id_condition = '(1=0)';
+		if ( $search_fields['id'] ) {
+			$search_trimmed = trim( $term );
+			$search_int     = absint( $search_trimmed );
+			if ( $search_int > 0 && ctype_digit( $search_trimmed ) ) {
+				$conditions[] = sprintf( "($wpdb->posts.ID = %d)", $search_int );
+			}
 		}
 
-		$conditions = $wpdb->prepare(
-			"( $id_condition OR ($wpdb->posts.post_title LIKE %s) OR ($wpdb->posts.guid LIKE %s) OR ($wpdb->posts.post_content LIKE %s) OR ($wpdb->posts.post_excerpt LIKE %s)",
-			$like, $like, $like, $like
-		);
+		if ( $search_fields['title'] ) {
+			$conditions[] = $wpdb->prepare( "($wpdb->posts.post_title LIKE %s)", $like );
+		}
+
+		if ( $search_fields['guid'] ) {
+			$conditions[] = $wpdb->prepare( "($wpdb->posts.guid LIKE %s)", $like );
+		}
+
+		if ( $search_fields['description'] ) {
+			$conditions[] = $wpdb->prepare( "($wpdb->posts.post_content LIKE %s)", $like );
+		}
+
+		if ( $search_fields['caption'] ) {
+			$conditions[] = $wpdb->prepare( "($wpdb->posts.post_excerpt LIKE %s)", $like );
+		}
 
 		// Alt text
-		$conditions .= $wpdb->prepare(
-			" OR EXISTS (SELECT 1 FROM $wpdb->postmeta WHERE $wpdb->postmeta.post_id = $wpdb->posts.ID AND $wpdb->postmeta.meta_key = '_wp_attachment_image_alt' AND $wpdb->postmeta.meta_value LIKE %s)",
-			$like
-		);
+		if ( $search_fields['alt_text'] ) {
+			$conditions[] = $wpdb->prepare(
+				"EXISTS (SELECT 1 FROM $wpdb->postmeta WHERE $wpdb->postmeta.post_id = $wpdb->posts.ID AND $wpdb->postmeta.meta_key = '_wp_attachment_image_alt' AND $wpdb->postmeta.meta_value LIKE %s)",
+				$like
+			);
+		}
 
 		// Filename
-		$conditions .= $wpdb->prepare(
-			" OR EXISTS (SELECT 1 FROM $wpdb->postmeta WHERE $wpdb->postmeta.post_id = $wpdb->posts.ID AND $wpdb->postmeta.meta_key = '_wp_attached_file' AND $wpdb->postmeta.meta_value LIKE %s)",
-			$like
-		);
+		if ( $search_fields['filename'] ) {
+			$conditions[] = $wpdb->prepare(
+				"EXISTS (SELECT 1 FROM $wpdb->postmeta WHERE $wpdb->postmeta.post_id = $wpdb->posts.ID AND $wpdb->postmeta.meta_key = '_wp_attached_file' AND $wpdb->postmeta.meta_value LIKE %s)",
+				$like
+			);
+		}
 
 		// Taxonomy
-		if ( ! empty( $taxes ) && ! empty( $tax_filter ) ) {
-			$conditions .= " OR EXISTS (SELECT 1 FROM $wpdb->term_relationships AS tr"
+		if ( $search_fields['taxonomy'] && ! empty( $taxes ) && ! empty( $tax_filter ) ) {
+			$conditions[] = "EXISTS (SELECT 1 FROM $wpdb->term_relationships AS tr"
 				. " INNER JOIN $wpdb->term_taxonomy AS tt ON (tr.term_taxonomy_id = tt.term_taxonomy_id AND $tax_filter)"
 				. " INNER JOIN $wpdb->terms AS t ON (tt.term_id = t.term_id)"
 				. " WHERE tr.object_id = $wpdb->posts.ID AND ("
@@ -306,9 +344,11 @@ class Media_Search_Enhanced {
 				. "))";
 		}
 
-		$conditions .= " )";
+		if ( empty( $conditions ) ) {
+			return '(1=0)';
+		}
 
-		return $conditions;
+		return '( ' . implode( ' OR ', $conditions ) . ' )';
 	}
 
 	/**

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -196,6 +196,83 @@ class SearchTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test 7b: Search fields can disable GUID matching without affecting title.
+	 */
+	public function test_search_fields_filter_can_disable_guid_matches() {
+		$guid_only_id = $this->create_attachment( array(
+			'post_title' => 'guid-filter-control-title',
+			'guid'       => 'http://example.org/wp-content/uploads/guid-filter-only-match.jpg',
+		) );
+		$title_id = $this->create_attachment( array(
+			'post_title' => 'guid-filter-title-match',
+			'guid'       => 'http://example.org/wp-content/uploads/unrelated-guid-value.jpg',
+		) );
+
+		$filter = function() {
+			return array( 'guid' => false );
+		};
+
+		add_filter( 'mse_search_fields', $filter );
+
+		try {
+			$guid_results  = $this->search_attachments( 'guid-filter-only-match' );
+			$title_results = $this->search_attachments( 'guid-filter-title-match' );
+		} finally {
+			remove_filter( 'mse_search_fields', $filter );
+		}
+
+		$this->assertNotContains( $guid_only_id, $guid_results, 'GUID-only matches should be skipped when guid search is disabled.' );
+		$this->assertContains( $title_id, $title_results, 'Other enabled fields should keep working when guid search is disabled.' );
+	}
+
+	/**
+	 * Test 7c: Search fields filter receives query and terms context.
+	 */
+	public function test_search_fields_filter_receives_query_context() {
+		$received_query = null;
+		$received_terms = null;
+
+		$filter = function( $fields, $query = null, $terms = null ) use ( &$received_query, &$received_terms ) {
+			$received_query = $query;
+			$received_terms = $terms;
+			return $fields;
+		};
+
+		add_filter( 'mse_search_fields', $filter, 10, 3 );
+
+		try {
+			$this->search_attachments( 'context-check-term' );
+		} finally {
+			remove_filter( 'mse_search_fields', $filter, 10 );
+		}
+
+		$this->assertInstanceOf( 'WP_Query', $received_query, 'Search field filters should receive the active WP_Query instance.' );
+		$this->assertSame( array( 'context-check-term' ), $received_terms, 'Search field filters should receive the parsed search terms.' );
+	}
+
+	/**
+	 * Test 7d: Disabling all search fields returns no results.
+	 */
+	public function test_search_fields_filter_can_disable_all_fields() {
+		$id = $this->create_attachment( array( 'post_title' => 'all-fields-disabled-test' ) );
+
+		$filter = function( $fields ) {
+			return array_fill_keys( array_keys( $fields ), false );
+		};
+
+		add_filter( 'mse_search_fields', $filter );
+
+		try {
+			$results = $this->search_attachments( 'all-fields-disabled-test' );
+		} finally {
+			remove_filter( 'mse_search_fields', $filter );
+		}
+
+		$this->assertNotContains( $id, $results, 'No results should be returned when every search field is disabled.' );
+		$this->assertEmpty( $results, 'Disabling every search field should force the search to return no results.' );
+	}
+
+	/**
 	 * Test 8: Search by taxonomy term name and slug.
 	 */
 	public function test_search_by_taxonomy_term() {
@@ -206,7 +283,8 @@ class SearchTest extends WP_UnitTestCase {
 
 		$id   = $this->create_attachment( array( 'post_title' => 'taxonomy-test-image' ) );
 		$term = wp_insert_term( 'Corporate Events', 'media_category', array(
-			'slug' => 'corporate-events',
+			'slug'        => 'corporate-events',
+			'description' => 'Quarterly leadership summit',
 		) );
 		wp_set_object_terms( $id, $term['term_id'], 'media_category' );
 
@@ -217,6 +295,10 @@ class SearchTest extends WP_UnitTestCase {
 		// Search by term slug.
 		$results = $this->search_attachments( 'corporate-events' );
 		$this->assertContains( $id, $results, 'Should find attachment by taxonomy term slug.' );
+
+		// Search by term description.
+		$results = $this->search_attachments( 'Quarterly leadership summit' );
+		$this->assertContains( $id, $results, 'Should find attachment by taxonomy term description.' );
 	}
 
 	/**
@@ -379,7 +461,6 @@ class SearchTest extends WP_UnitTestCase {
 		$id = $this->create_attachment( array( 'post_title' => 'ajax-fallback-test' ) );
 
 		// Simulate the AJAX media modal request.
-		add_filter( 'mse_allow_multi_term_search', '__return_true' );
 		$_REQUEST['query']  = array(
 			's'         => 'ajax-fallback-test',
 			'post_type' => 'attachment',
@@ -437,7 +518,12 @@ class SearchTest extends WP_UnitTestCase {
 		) );
 
 		wp_set_current_user( $author_a );
-		$results = $this->search_attachments( 'private' );
+
+		try {
+			$results = $this->search_attachments( 'private' );
+		} finally {
+			wp_set_current_user( 0 );
+		}
 
 		$this->assertContains( $own_private, $results, 'Author should find their own private attachment.' );
 		$this->assertNotContains( $other_private, $results, 'Author should not find another author\'s private attachment.' );

--- a/tests/benchmark/LargeScaleProfilingTest.php
+++ b/tests/benchmark/LargeScaleProfilingTest.php
@@ -15,6 +15,7 @@ class LargeScaleProfilingTest extends WP_UnitTestCase {
 	 * @var int[] Attachment IDs created during seeding.
 	 */
 	private static $attachment_ids = array();
+	private static $scenario_terms = array();
 
 	/**
 	 * @var int Number of attachments seeded.
@@ -57,20 +58,57 @@ class LargeScaleProfilingTest extends WP_UnitTestCase {
 				wp_set_object_terms( $id, $term_name, 'media_tag' );
 			}
 		}
+
+		self::$scenario_terms = array(
+			'title'    => 'profiling-special-title-only',
+			'alt'      => 'profiling-special-alt-only',
+			'filename' => 'profiling-special-file-only',
+			'taxonomy' => 'profiling-special-taxonomy-only',
+			'none'     => 'profiling-special-no-match',
+		);
+
+		$title_id = $factory->attachment->create( array(
+			'post_title'     => self::$scenario_terms['title'],
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'image/jpeg',
+		) );
+		$alt_id = $factory->attachment->create( array(
+			'post_title'     => 'profiling-special-alt-holder',
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'image/jpeg',
+		) );
+		$file_id = $factory->attachment->create( array(
+			'post_title'     => 'profiling-special-file-holder',
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'image/jpeg',
+		) );
+		$taxonomy_id = $factory->attachment->create( array(
+			'post_title'     => 'profiling-special-taxonomy-holder',
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'image/jpeg',
+		) );
+
+		update_post_meta( $alt_id, '_wp_attachment_image_alt', self::$scenario_terms['alt'] );
+		update_post_meta( $file_id, '_wp_attached_file', '2024/01/' . self::$scenario_terms['filename'] . '.jpg' );
+		wp_insert_term( self::$scenario_terms['taxonomy'], 'media_tag' );
+		wp_set_object_terms( $taxonomy_id, self::$scenario_terms['taxonomy'], 'media_tag' );
+
+		self::$attachment_ids[] = $title_id;
+		self::$attachment_ids[] = $alt_id;
+		self::$attachment_ids[] = $file_id;
+		self::$attachment_ids[] = $taxonomy_id;
 	}
 
 	/**
-	 * Profile a search query and log detailed results.
+	 * Profile a search query and capture the generated SQL.
+	 *
+	 * @param string $search Search term.
+	 * @return array { sql: string, time: float, results_count: int }
 	 */
-	public function test_large_scale_query_profiling() {
+	private function profile_query( $search ) {
 		global $wpdb, $wp_query;
 
 		$wpdb->queries = array();
-		if ( ! defined( 'SAVEQUERIES' ) ) {
-			define( 'SAVEQUERIES', true );
-		}
-
-		$search = 'profiling-attachment';
 
 		$args = array(
 			'post_type'   => 'attachment',
@@ -79,45 +117,107 @@ class LargeScaleProfilingTest extends WP_UnitTestCase {
 			'fields'      => 'ids',
 		);
 
-		// The plugin reads from global $wp_query->query_vars.
 		$original_vars        = $wp_query->query_vars;
 		$wp_query->query_vars = $args;
 
 		$start = microtime( true );
-
 		$query = new WP_Query( $args );
-
 		$elapsed = microtime( true ) - $start;
 
 		$wp_query->query_vars = $original_vars;
 
-		// Find the main query SQL.
-		$captured_sql = '';
+		$search_needle = trim( explode( ',', $search )[0] );
+		$captured_sql  = '';
 		foreach ( $wpdb->queries as $q ) {
-			if ( stripos( $q[0], $search ) !== false && stripos( $q[0], 'SELECT' ) !== false ) {
+			if ( stripos( $q[0], $search_needle ) !== false && stripos( $q[0], 'SELECT' ) !== false ) {
 				$captured_sql = $q[0];
 				break;
 			}
 		}
 
-		$this->assertNotEmpty( $captured_sql, 'Should have captured the search SQL.' );
+		return array(
+			'sql'           => $captured_sql,
+			'time'          => $elapsed,
+			'results_count' => $query->found_posts,
+		);
+	}
 
-		// Run EXPLAIN.
-		$explain = $wpdb->get_results( 'EXPLAIN ' . $captured_sql );
+	/**
+	 * Profile a search query and log detailed results.
+	 */
+	public function test_large_scale_query_profiling() {
+		global $wpdb;
 
-		// Detailed log output.
+		if ( ! defined( 'SAVEQUERIES' ) ) {
+			define( 'SAVEQUERIES', true );
+		}
+
+		$scenarios = array(
+			array(
+				'label'  => 'broad-title',
+				'search' => 'profiling-attachment',
+			),
+			array(
+				'label'  => 'title-only',
+				'search' => self::$scenario_terms['title'],
+			),
+			array(
+				'label'  => 'alt-only',
+				'search' => self::$scenario_terms['alt'],
+			),
+			array(
+				'label'  => 'filename-only',
+				'search' => self::$scenario_terms['filename'],
+			),
+			array(
+				'label'  => 'taxonomy-only',
+				'search' => self::$scenario_terms['taxonomy'],
+			),
+			array(
+				'label'      => 'multi-term',
+				'search'     => self::$scenario_terms['title'] . ', ' . self::$scenario_terms['alt'],
+				'multi_term' => true,
+			),
+			array(
+				'label'  => 'zero-match',
+				'search' => self::$scenario_terms['none'],
+			),
+		);
+
 		$log  = sprintf( "\n=== Large-Scale Profiling (%s attachments) ===\n", number_format( self::$count ) );
-		$log .= sprintf( "Results found: %d\n", $query->found_posts );
-		$log .= sprintf( "Query time: %.4f seconds\n", $elapsed );
-		$log .= "SQL:\n" . $captured_sql . "\n\n";
-		$log .= "EXPLAIN output:\n";
 
-		if ( ! empty( $explain ) ) {
-			$headers = array_keys( get_object_vars( $explain[0] ) );
-			$log    .= implode( "\t", $headers ) . "\n";
-			foreach ( $explain as $row ) {
-				$log .= implode( "\t", array_values( get_object_vars( $row ) ) ) . "\n";
+		foreach ( $scenarios as $scenario ) {
+			if ( ! empty( $scenario['multi_term'] ) ) {
+				add_filter( 'mse_allow_multi_term_search', '__return_true' );
 			}
+
+			try {
+				$result = $this->profile_query( $scenario['search'] );
+			} finally {
+				if ( ! empty( $scenario['multi_term'] ) ) {
+					remove_filter( 'mse_allow_multi_term_search', '__return_true' );
+				}
+			}
+
+			$this->assertNotEmpty( $result['sql'], sprintf( 'Should have captured the search SQL for %s.', $scenario['label'] ) );
+
+			$explain = $wpdb->get_results( 'EXPLAIN ' . $result['sql'] );
+
+			$log .= sprintf( "-- %s (%s) --\n", $scenario['label'], $scenario['search'] );
+			$log .= sprintf( "Results found: %d\n", $result['results_count'] );
+			$log .= sprintf( "Query time: %.4f seconds\n", $result['time'] );
+			$log .= "SQL:\n" . $result['sql'] . "\n";
+			$log .= "EXPLAIN output:\n";
+
+			if ( ! empty( $explain ) ) {
+				$headers = array_keys( get_object_vars( $explain[0] ) );
+				$log    .= implode( "\t", $headers ) . "\n";
+				foreach ( $explain as $row ) {
+					$log .= implode( "\t", array_values( get_object_vars( $row ) ) ) . "\n";
+				}
+			}
+
+			$log .= "\n";
 		}
 
 		$log .= "================================================\n";

--- a/tests/benchmark/QueryStructureTest.php
+++ b/tests/benchmark/QueryStructureTest.php
@@ -196,6 +196,45 @@ class QueryStructureTest extends WP_UnitTestCase {
 		$this->assertGreaterThanOrEqual( 4, $exists_count, 'Multi-term search should have EXISTS subqueries for each term (at least 2 per term).' );
 	}
 
+	public function test_search_fields_filter_removes_guid_and_taxonomy_clauses() {
+		$filter = function( $fields ) {
+			$fields['guid']     = false;
+			$fields['taxonomy'] = false;
+			return $fields;
+		};
+
+		add_filter( 'mse_search_fields', $filter );
+
+		try {
+			$result = $this->capture_query( 'benchmark-attachment' );
+		} finally {
+			remove_filter( 'mse_search_fields', $filter );
+		}
+
+		$this->assertNotEmpty( $result['sql'], 'Should have captured the search SQL.' );
+		$this->assertStringNotContainsString( '.guid LIKE', $result['sql'], 'GUID clause should be omitted when guid search is disabled.' );
+		$this->assertStringNotContainsString( 'term_relationships AS tr', $result['sql'], 'Taxonomy EXISTS clause should be omitted when taxonomy search is disabled.' );
+		$this->assertStringContainsString( 'post_title LIKE', $result['sql'], 'Other enabled fields should remain in the query.' );
+	}
+
+	public function test_search_fields_filter_removes_id_clause() {
+		$filter = function() {
+			return array( 'id' => false );
+		};
+
+		add_filter( 'mse_search_fields', $filter );
+
+		try {
+			$result = $this->capture_query( '12345' );
+		} finally {
+			remove_filter( 'mse_search_fields', $filter );
+		}
+
+		$this->assertNotEmpty( $result['sql'], 'Should have captured the search SQL.' );
+		$this->assertDoesNotMatchRegularExpression( '/\.ID\s*=\s*\'?12345/i', $result['sql'], 'Exact ID clause should be omitted when ID search is disabled.' );
+		$this->assertStringContainsString( 'post_title LIKE', $result['sql'], 'Other enabled fields should remain in the query when ID search is disabled.' );
+	}
+
 	/**
 	 * Log EXPLAIN output and timing for manual review.
 	 * No assertions — optimizer output varies across MySQL/MariaDB versions.


### PR DESCRIPTION
## Summary

This PR adds a low-risk tuning hook for large media libraries without changing default search behavior.

- add `mse_search_fields` so sites can disable expensive clauses like `guid` or `taxonomy`
- pass the active `WP_Query` and parsed search terms into that filter for context-aware tuning
- document the hook in both `README.md` and `README.txt`
- add regression coverage for partial field overrides, all-fields-disabled behavior, taxonomy description matching, and ID clause removal
- expand the slow profiling test to log title-only, alt-only, filename-only, taxonomy-only, multi-term, and zero-match scenarios
- update issue #22 with a phased checklist and mark the completed Phase 1 items

This moves issue #22 forward but does not close it.

## Testing

- `composer test`
- `MSE_PROFILE_COUNT=500 vendor/bin/phpunit --group slow --filter test_large_scale_query_profiling`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/media-search-enhanced/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
