### PR TITLE
Add Phase 2 composite-index benchmark and null-result writeup

### DIFF
--- a/docs/phase-2-index-benchmarks.md
+++ b/docs/phase-2-index-benchmarks.md
@@ -211,7 +211,7 @@ This is the snippet the maintainer could drop into `README.md` if future
 data changes the conclusion. **Do not merge this into `README.md` now** —
 the current data does not support it.
 
-```markdown
+~~~markdown
 ### Optional: composite index on `wp_postmeta` (advanced)
 
 On very large libraries (hundreds of thousands of attachments), a DBA may
@@ -227,7 +227,7 @@ This is **not recommended by default**. At 5k and 20k attachments on MySQL
 8.0 we observed no measurable improvement; the existing `wp_postmeta.post_id`
 index already handles the correlated lookup. Evaluate with
 `bin/profile.sh` against your own data before deploying.
-```
+~~~
 
 ## Follow-ups out of scope for this doc
 

--- a/docs/phase-2-index-benchmarks.md
+++ b/docs/phase-2-index-benchmarks.md
@@ -1,0 +1,242 @@
+# Phase 2: composite `wp_postmeta` index benchmarks
+
+Issue [#22](https://github.com/1fixdotio/media-search-enhanced/issues/22) Phase 2
+asks whether a composite index on `wp_postmeta` would speed up the correlated
+`EXISTS` subqueries this plugin emits for alt text and filename lookups. This
+document records the empirical data and the recommendation.
+
+## TL;DR
+
+**A composite index is not recommended.** At 5k and 20k attachments, on MySQL
+8.0, the candidate index is neutral-to-slightly-worse across every scenario we
+tested. The EXISTS subqueries are already cheap (1-2 row lookups) because the
+stock `wp_postmeta.post_id` index handles the correlation, and the leading-wildcard
+`LIKE '%term%'` is non-sargable regardless of index shape. The performance
+ceiling is elsewhere (outer `wp_posts` scan, taxonomy joins) and Phase 3
+(denormalized search index) is the right next step.
+
+## Candidate tested
+
+A single composite:
+
+```sql
+ALTER TABLE wp_postmeta ADD INDEX mse_phase2_idx_meta_key_post_id_value
+    (meta_key, post_id, meta_value(191));
+```
+
+Rationale: the EXISTS subqueries have the shape
+`WHERE post_id = X AND meta_key = 'K' AND meta_value LIKE '%term%'`. The leading
+wildcard makes the `LIKE` non-sargable, so an index can only help the equality
+portion. A `(meta_key, post_id)` prefix satisfies both equalities, and trailing
+`meta_value(191)` keeps the non-sargable `LIKE` inside the index leaves so
+InnoDB doesn't have to visit the clustered PK.
+
+### What we deliberately did not test
+
+- `(meta_key, meta_value(191))` — drops the `post_id` correlation column,
+  which is exactly the part the optimizer currently uses most effectively
+  (see EXPLAIN below). Strictly worse on paper, skipped.
+- `(post_id, meta_key, meta_value(191))` — duplicates the existing stock
+  `post_id` single-column index; prefix leads with the same column.
+
+## How to reproduce
+
+The benchmark harness is `tests::LargeScaleProfilingTest::test_phase2_composite_index_comparison`.
+It runs under the same `--group slow` / `bin/profile.sh` path as the existing
+one-pass profiling test, shares its seeded fixtures, and creates + drops the
+candidate index inside a single test method (with a `register_shutdown_function`
+guard so a fatal still drops the index).
+
+```bash
+bin/profile.sh 5000  2>&1 | tee /tmp/phase2-profile-5k.txt
+bin/profile.sh 20000 2>&1 | tee /tmp/phase2-profile-20k.txt
+```
+
+### Methodology
+
+- Each scenario runs **3 measured passes** after a discarded warmup pass on the
+  same schema state (so buffer-pool warmth is comparable before vs. after).
+- Between passes, `wp_cache_flush()` empties the WP object cache and
+  `WP_Query` is called with `cache_results => false` so the measurements hit
+  MySQL instead of returning from WP's result cache.
+- Wall-clock times reported as min / median across the 3 runs.
+- InnoDB `FLUSH TABLES` is **not** used — it isn't representative of a
+  production host's hot-cache state.
+
+## Results
+
+### 5,000 attachments (`bin/profile.sh 5000`)
+
+Captured to `/tmp/phase2-profile-5k.txt`.
+
+| scenario      | before\_min | before\_med | after\_min | after\_med | delta\_med |
+|---------------|------------:|------------:|-----------:|-----------:|-----------:|
+| zero-match    |      0.1132 |      0.1137 |     0.1158 |     0.1169 |    +0.0032 |
+| broad-title   |      0.0078 |      0.0080 |     0.0078 |     0.0082 |    +0.0002 |
+| title-only    |      0.1135 |      0.1136 |     0.1139 |     0.1141 |    +0.0005 |
+| alt-only      |      0.1130 |      0.1144 |     0.1141 |     0.1162 |    +0.0017 |
+| filename-only |      0.1135 |      0.1140 |     0.1140 |     0.1145 |    +0.0004 |
+| taxonomy-only |      0.1154 |      0.1163 |     0.1163 |     0.1170 |    +0.0007 |
+| multi-term    |      0.2221 |      0.2232 |     0.2220 |     0.2222 |    -0.0010 |
+
+EXPLAIN for the two `wp_postmeta` subqueries (representative — same for every
+scenario):
+
+```
+BEFORE
+  DEPENDENT SUBQUERY  wptests_postmeta  key=post_id                              rows=1  filtered=5.55  Using where
+  DEPENDENT SUBQUERY  wptests_postmeta  key=post_id                              rows=1  filtered=5.55  Using where
+
+AFTER
+  DEPENDENT SUBQUERY  wptests_postmeta  key=mse_phase2_idx_meta_key_post_id_value  rows=1  filtered=11.11 Using where
+  DEPENDENT SUBQUERY  wptests_postmeta  key=mse_phase2_idx_meta_key_post_id_value  rows=1  filtered=11.11 Using where
+```
+
+### 20,000 attachments (`bin/profile.sh 20000`)
+
+Captured to `/tmp/phase2-profile-20k.txt`.
+
+| scenario      | before\_min | before\_med | after\_min | after\_med | delta\_med |
+|---------------|------------:|------------:|-----------:|-----------:|-----------:|
+| zero-match    |      0.4546 |      0.4560 |     0.4558 |     0.4582 |    +0.0022 |
+| broad-title   |      0.0261 |      0.0261 |     0.0263 |     0.0273 |    +0.0012 |
+| title-only    |      0.4562 |      0.4564 |     0.4534 |     0.4550 |    -0.0014 |
+| alt-only      |      0.4537 |      0.4542 |     0.4545 |     0.4566 |    +0.0024 |
+| filename-only |      0.4548 |      0.4575 |     0.4562 |     0.4566 |    -0.0009 |
+| taxonomy-only |      0.4652 |      0.4652 |     0.4663 |     0.4690 |    +0.0037 |
+| multi-term    |      0.8920 |      0.8951 |     0.8962 |     0.8967 |    +0.0015 |
+
+Same EXPLAIN shift for the `wp_postmeta` subqueries as at 5k:
+
+```
+BEFORE
+  DEPENDENT SUBQUERY  wptests_postmeta  key=post_id                              rows=2  filtered=5.56  Using where
+  DEPENDENT SUBQUERY  wptests_postmeta  key=post_id                              rows=2  filtered=5.56  Using where
+
+AFTER
+  DEPENDENT SUBQUERY  wptests_postmeta  key=mse_phase2_idx_meta_key_post_id_value  rows=1  filtered=11.11 Using where
+  DEPENDENT SUBQUERY  wptests_postmeta  key=mse_phase2_idx_meta_key_post_id_value  rows=1  filtered=11.11 Using where
+```
+
+The outer `wp_posts` access stays on `type_status_date` with
+`rows=9,844, filtered=100.00`. Taxonomy subquery access is unchanged.
+
+## Interpretation
+
+- **Plan switch is real.** When the composite exists, MySQL picks it over
+  `post_id` for both EXISTS subqueries. The change is stable across scales —
+  no plan flip between 5k and 20k — so this isn't an optimizer corner case
+  that resolves itself at higher volume.
+- **Savings from the plan switch are not real.** The stock `post_id` index
+  already gives `rows=1-2`, and the composite gives `rows=1`. That's a
+  1-to-2-row difference per subquery execution. At 20k attachments with 9,844
+  posts matching the outer `type_status_date` ref lookup, the subquery is
+  executed per outer row, but each execution is already bound to the same
+  tiny cost either way. There's nothing meaningful left to save at the meta
+  level.
+- **Where the time actually goes.** At 20k, the ~0.45s for a single-result
+  scenario is dominated by the outer scan over all attachments (9,844 rows ×
+  whatever per-row subquery cost), not by the postmeta lookups themselves.
+  The `LIKE '%..%'` on `post_title`, `post_content`, `post_excerpt`, `guid`
+  cannot use any index regardless of what we do to `postmeta`.
+- **Variance is comparable to the deltas.** The largest regression observed
+  (+0.0127s on multi-term at 20k in an earlier isolated run, +0.0015s in the
+  full run) is within the noise floor at n=3. Don't read "the composite
+  makes things slower" into this — read it as "no meaningful movement in
+  either direction."
+- **Why the task brief's "rows ≈ 500, filtered = 1.11%" doesn't show up here.**
+  That plan is the EXPLAIN for the correctness-test fixture, which has only
+  a handful of attachments per term. At 5k+ the optimizer has enough stats
+  to prefer the tighter `post_id` correlation path. So the "500 rows scanned
+  per subquery" observation was specific to tiny fixtures and is not the
+  scaling behavior we need to optimize for.
+
+## Per-scenario summary
+
+| scenario      | does the index help? | notes                                                                 |
+|---------------|----------------------|-----------------------------------------------------------------------|
+| zero-match    | no                   | Outer scan dominates; postmeta probe is already cheap.                |
+| broad-title   | no                   | Short-circuits on `post_title LIKE` before postmeta even runs.        |
+| title-only    | no (noise)           | Same as above — postmeta is not on the hot path.                      |
+| alt-only      | no                   | The one scenario where postmeta matters most; no measurable win.      |
+| filename-only | no                   | Same as alt-only.                                                     |
+| taxonomy-only | no                   | Taxonomy joins dominate; index doesn't touch them.                    |
+| multi-term    | no                   | Doubles the EXISTS count but still bounded by the single outer scan.  |
+
+No scenario shows a consistent win. No scenario shows a large regression.
+
+## Recommendation
+
+### Should a composite `wp_postmeta` index be added?
+
+**No**, not as a general recommendation, and not as something the plugin
+should create on activation. The measured improvement is within noise and
+the index carries real costs on production sites:
+
+- index write amplification on every `update_post_meta` (every attachment
+  edit, media-library scroll triggering regenerated thumbnails, etc.),
+- buffer-pool pressure — `wp_postmeta` is one of the largest tables on most
+  sites,
+- schema ownership boundaries — sites with managed hosting (WP Engine,
+  Pantheon, Kinsta) typically do not accept plugin-initiated DDL on core
+  tables, and a plugin silently changing `wp_postmeta` structure would be
+  rejected by any competent DBA review.
+
+### Does the guidance belong in `README.md` or developer docs?
+
+**Developer docs only.** Rationale:
+
+- `README.md` / `README.txt` are read by site owners deciding whether to
+  install the plugin. A DBA-level discussion of `wp_postmeta` indexes on
+  that page invites cargo-cult additions of the index (with the costs
+  above) on sites where it will not measurably help.
+- Phase 2's open question in issue #22 is "Decide whether any index
+  guidance belongs in the main README." The empirical answer is that
+  there isn't guidance worth giving yet: "we tried it, it didn't help."
+  That belongs in this file, not in the README.
+- If Phase 3 (denormalized search table) lands, *that* table's indexes
+  are the plugin's own and the plugin can create them freely — at which
+  point the README discussion is about turning that feature on, not
+  about modifying core WordPress tables.
+
+If a future contributor wants to revisit this for a specific workload
+(e.g. a site with millions of attachments where the outer scan is no
+longer the bottleneck), the harness in
+`tests/benchmark/LargeScaleProfilingTest.php::test_phase2_composite_index_comparison`
+is the starting point — add a new candidate index shape, rerun, compare.
+
+### If a recommendation were ever added to README
+
+This is the snippet the maintainer could drop into `README.md` if future
+data changes the conclusion. **Do not merge this into `README.md` now** —
+the current data does not support it.
+
+```markdown
+### Optional: composite index on `wp_postmeta` (advanced)
+
+On very large libraries (hundreds of thousands of attachments), a DBA may
+evaluate adding a composite index to `wp_postmeta` to reduce the cost of
+the plugin's alt-text and filename EXISTS subqueries:
+
+```sql
+ALTER TABLE wp_postmeta ADD INDEX mse_meta_key_post_value
+    (meta_key, post_id, meta_value(191));
+```
+
+This is **not recommended by default**. At 5k and 20k attachments on MySQL
+8.0 we observed no measurable improvement; the existing `wp_postmeta.post_id`
+index already handles the correlated lookup. Evaluate with
+`bin/profile.sh` against your own data before deploying.
+```
+
+## Follow-ups out of scope for this doc
+
+- A future `MSE_CLI` subcommand that creates the candidate index on demand
+  and then `EXPLAIN ANALYZE`s a representative query before/after — nice
+  for site-operators who want their own numbers but **not** something the
+  plugin should do without explicit operator action. Tracked in issue #22
+  as a Phase 2 follow-up suggestion.
+- Phase 3: a plugin-owned denormalized search table keyed by attachment
+  ID. The data above makes this the more promising direction: it
+  eliminates the `LIKE '%..%'` on `wp_posts.post_title` etc., which is
+  where the actual scaling pain is.

--- a/tests/benchmark/LargeScaleProfilingTest.php
+++ b/tests/benchmark/LargeScaleProfilingTest.php
@@ -129,7 +129,7 @@ class LargeScaleProfilingTest extends WP_UnitTestCase {
 		$search_needle = trim( explode( ',', $search )[0] );
 		$captured_sql  = '';
 		foreach ( $wpdb->queries as $q ) {
-			if ( stripos( $q[0], $search_needle ) !== false && stripos( $q[0], 'SELECT' ) !== false ) {
+			if ( stripos( $q[0], $search_needle ) !== false && stripos( $q[0], $wpdb->posts ) !== false ) {
 				$captured_sql = $q[0];
 				break;
 			}
@@ -354,7 +354,7 @@ class LargeScaleProfilingTest extends WP_UnitTestCase {
 		$search_needle = trim( explode( ',', $search )[0] );
 		$captured_sql  = '';
 		foreach ( $wpdb->queries as $q ) {
-			if ( stripos( $q[0], $search_needle ) !== false && stripos( $q[0], 'SELECT' ) !== false ) {
+			if ( stripos( $q[0], $search_needle ) !== false && stripos( $q[0], $wpdb->posts ) !== false ) {
 				$captured_sql = $q[0];
 				break;
 			}

--- a/tests/benchmark/LargeScaleProfilingTest.php
+++ b/tests/benchmark/LargeScaleProfilingTest.php
@@ -226,4 +226,324 @@ class LargeScaleProfilingTest extends WP_UnitTestCase {
 
 		$this->assertTrue( true );
 	}
+
+	/**
+	 * Phase 2 composite-index comparison.
+	 *
+	 * Captures EXPLAIN + wall-clock timing for each scenario twice:
+	 *   1. Against WordPress core's default wp_postmeta schema
+	 *      (PRIMARY, post_id, meta_key(191)).
+	 *   2. After adding a candidate composite index on wp_postmeta:
+	 *      (meta_key, post_id, meta_value(191)).
+	 *
+	 * The index is created inside this test method and dropped in finally{}
+	 * plus a register_shutdown_function guard, so the schema is always
+	 * restored — even on a fatal error. No schema change is performed by the
+	 * plugin itself: this test is a measurement tool for Phase 2 of #22.
+	 *
+	 * Reuses the same seeded attachments (class fixtures) as
+	 * test_large_scale_query_profiling so a single `bin/profile.sh N` run
+	 * covers both measurements without double-seeding the DB.
+	 */
+	const PHASE2_INDEX_NAME = 'mse_phase2_idx_meta_key_post_id_value';
+
+	public function test_phase2_composite_index_comparison() {
+		global $wpdb;
+
+		if ( ! defined( 'SAVEQUERIES' ) ) {
+			define( 'SAVEQUERIES', true );
+		}
+
+		$runs = 3;
+
+		// Belt-and-braces: if the process fatals between CREATE INDEX and the
+		// finally{} below, still drop the index so the schema is clean for
+		// subsequent runs. DDL implicitly commits, so the tear-down
+		// transaction-rollback WP_UnitTestCase does between tests is not a
+		// safety net for us.
+		register_shutdown_function( array( __CLASS__, 'phase2_drop_candidate_index' ) );
+
+		// Warm the InnoDB buffer pool before measuring "before". Otherwise the
+		// first scenario would pay the page-load cost and look artificially
+		// slow, inflating the apparent "after" improvement.
+		$this->phase2_run_scenarios( 1 );
+
+		$before = $this->phase2_run_scenarios( $runs );
+
+		$after = array();
+		try {
+			self::phase2_create_candidate_index();
+			// Warm again so the first "after" measurement isn't penalized by
+			// the cold-cache cost of loading the new index's pages.
+			$this->phase2_run_scenarios( 1 );
+			$after = $this->phase2_run_scenarios( $runs );
+		} finally {
+			self::phase2_drop_candidate_index();
+		}
+
+		fwrite( STDERR, $this->phase2_format_diff_report( $before, $after ) );
+
+		// Informational benchmark: just confirm we captured data for every
+		// scenario under both conditions. Timings themselves are not asserted.
+		foreach ( array_keys( $before ) as $label ) {
+			$this->assertArrayHasKey( $label, $after, "Missing 'after' capture for {$label}" );
+			$this->assertNotEmpty( $before[ $label ]['sql'], "No SQL captured for {$label} (before)" );
+			$this->assertNotEmpty( $after[ $label ]['sql'],  "No SQL captured for {$label} (after)" );
+		}
+	}
+
+	/**
+	 * Scenario list for the Phase 2 comparison. Mirrors the scenarios used by
+	 * test_large_scale_query_profiling so before/after can be related to the
+	 * one-pass EXPLAIN dump above.
+	 *
+	 * @return array<int,array{label:string,search:string,multi_term?:bool}>
+	 */
+	private function phase2_scenarios() {
+		return array(
+			array( 'label' => 'zero-match',    'search' => self::$scenario_terms['none'] ),
+			array( 'label' => 'broad-title',   'search' => 'profiling-attachment' ),
+			array( 'label' => 'title-only',    'search' => self::$scenario_terms['title'] ),
+			array( 'label' => 'alt-only',      'search' => self::$scenario_terms['alt'] ),
+			array( 'label' => 'filename-only', 'search' => self::$scenario_terms['filename'] ),
+			array( 'label' => 'taxonomy-only', 'search' => self::$scenario_terms['taxonomy'] ),
+			array(
+				'label'      => 'multi-term',
+				'search'     => self::$scenario_terms['title'] . ', ' . self::$scenario_terms['alt'],
+				'multi_term' => true,
+			),
+		);
+	}
+
+	/**
+	 * Run a single search and capture SQL, wall-clock time, and result count.
+	 *
+	 * We flush the WP object cache and disable WP_Query result-caching for
+	 * each invocation so the N measured runs actually hit MySQL — otherwise
+	 * only the first run pays the real query cost and the rest return from
+	 * object cache, giving meaningless sub-millisecond timings.
+	 *
+	 * @param string $search Search term.
+	 * @return array{sql:string,time:float,results_count:int}
+	 */
+	private function phase2_profile_query( $search ) {
+		global $wpdb, $wp_query;
+
+		$wpdb->queries = array();
+		wp_cache_flush();
+
+		$args = array(
+			'post_type'              => 'attachment',
+			'post_status'            => 'inherit',
+			's'                      => $search,
+			'fields'                 => 'ids',
+			'cache_results'          => false,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+		);
+
+		$original_vars        = $wp_query->query_vars;
+		$wp_query->query_vars = $args;
+
+		$start   = microtime( true );
+		$query   = new WP_Query( $args );
+		$elapsed = microtime( true ) - $start;
+
+		$wp_query->query_vars = $original_vars;
+
+		$search_needle = trim( explode( ',', $search )[0] );
+		$captured_sql  = '';
+		foreach ( $wpdb->queries as $q ) {
+			if ( stripos( $q[0], $search_needle ) !== false && stripos( $q[0], 'SELECT' ) !== false ) {
+				$captured_sql = $q[0];
+				break;
+			}
+		}
+
+		return array(
+			'sql'           => $captured_sql,
+			'time'          => $elapsed,
+			'results_count' => $query->found_posts,
+		);
+	}
+
+	/**
+	 * Execute every scenario $runs times and return a per-scenario bundle:
+	 *   [label => ['sql' => .., 'times' => [..], 'results_count' => .., 'explain' => [..] ]]
+	 *
+	 * SQL and EXPLAIN are captured from the last run so they reflect the
+	 * current schema state (important because "after" runs with the candidate
+	 * index created). Times are collected from all runs for min/median.
+	 *
+	 * @param int $runs Number of measured runs per scenario.
+	 * @return array
+	 */
+	private function phase2_run_scenarios( $runs ) {
+		global $wpdb;
+
+		$out = array();
+		foreach ( $this->phase2_scenarios() as $scenario ) {
+			if ( ! empty( $scenario['multi_term'] ) ) {
+				add_filter( 'mse_allow_multi_term_search', '__return_true' );
+			}
+
+			$times         = array();
+			$last_sql      = '';
+			$results_count = 0;
+
+			try {
+				for ( $i = 0; $i < $runs; $i++ ) {
+					$res           = $this->phase2_profile_query( $scenario['search'] );
+					$times[]       = $res['time'];
+					$last_sql      = $res['sql'];
+					$results_count = $res['results_count'];
+				}
+			} finally {
+				if ( ! empty( $scenario['multi_term'] ) ) {
+					remove_filter( 'mse_allow_multi_term_search', '__return_true' );
+				}
+			}
+
+			$explain_rows = $last_sql !== '' ? $wpdb->get_results( 'EXPLAIN ' . $last_sql ) : array();
+
+			$out[ $scenario['label'] ] = array(
+				'search'        => $scenario['search'],
+				'sql'           => $last_sql,
+				'times'         => $times,
+				'results_count' => $results_count,
+				'explain'       => $explain_rows,
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Create the candidate composite index:
+	 *   (meta_key, post_id, meta_value(191))
+	 *
+	 * Why this shape: the EXISTS subqueries emitted by build_search_conditions
+	 * have the form `WHERE post_id = X AND meta_key = 'K' AND meta_value LIKE
+	 * '%..%'`. The leading wildcard makes the LIKE non-sargable, so an index
+	 * can only help with the equality portion. This composite gives MySQL:
+	 *   - leading `meta_key` for the equality filter,
+	 *   - `post_id` for the correlation back to wp_posts.ID,
+	 *   - `meta_value(191)` as a trailing covering column so the non-sargable
+	 *     LIKE can be evaluated against the index leaves rather than by
+	 *     jumping back to the clustered PK.
+	 */
+	private static function phase2_create_candidate_index() {
+		global $wpdb;
+
+		// Defensive: drop any stale copy left by a crashed prior run.
+		self::phase2_drop_candidate_index();
+
+		$wpdb->query( sprintf(
+			'ALTER TABLE %s ADD INDEX %s (meta_key, post_id, meta_value(191))',
+			$wpdb->postmeta,
+			self::PHASE2_INDEX_NAME
+		) );
+	}
+
+	/**
+	 * Drop the candidate index unconditionally. Safe to call repeatedly.
+	 */
+	public static function phase2_drop_candidate_index() {
+		global $wpdb;
+
+		$wpdb->suppress_errors( true );
+		$wpdb->query( sprintf(
+			'ALTER TABLE %s DROP INDEX %s',
+			$wpdb->postmeta,
+			self::PHASE2_INDEX_NAME
+		) );
+		$wpdb->suppress_errors( false );
+	}
+
+	/**
+	 * Format a human-readable side-by-side report: timing summary, then
+	 * EXPLAIN deltas for the wp_postmeta subqueries per scenario.
+	 */
+	private function phase2_format_diff_report( array $before, array $after ) {
+		$log  = "\n";
+		$log .= sprintf(
+			"=== Phase 2 Composite Index Comparison (%s attachments, index=(meta_key, post_id, meta_value(191)) as %s) ===\n",
+			number_format( self::$count ),
+			self::PHASE2_INDEX_NAME
+		);
+		$log .= "Methodology: 1 warmup pass per condition (discarded), then 3 measured runs per scenario.\n";
+		$log .= "All WP object caches flushed between runs; WP_Query result caching disabled so each run hits MySQL.\n";
+		$log .= "Reporting min/median wall-clock across the 3 measured runs, in seconds.\n\n";
+
+		$log .= "-- Timing summary --\n";
+		$log .= sprintf(
+			"%-16s %12s %12s %12s %12s %12s\n",
+			'scenario', 'before_min', 'before_med', 'after_min', 'after_med', 'delta_med'
+		);
+		foreach ( $before as $label => $b ) {
+			$a     = $after[ $label ];
+			$b_min = min( $b['times'] );
+			$b_med = $this->phase2_median( $b['times'] );
+			$a_min = min( $a['times'] );
+			$a_med = $this->phase2_median( $a['times'] );
+			$delta = $a_med - $b_med;
+			$log  .= sprintf(
+				"%-16s %12.4f %12.4f %12.4f %12.4f %+12.4f\n",
+				$label, $b_min, $b_med, $a_min, $a_med, $delta
+			);
+		}
+		$log .= "\n";
+
+		$log .= "-- EXPLAIN diff (key / rows / filtered / Extra) per scenario --\n";
+		foreach ( $before as $label => $b ) {
+			$a    = $after[ $label ];
+			$log .= sprintf( "[%s]  results=%d  search=%s\n", $label, $b['results_count'], $b['search'] );
+			$log .= "  BEFORE:\n" . $this->phase2_explain_summary( $b['explain'] );
+			$log .= "  AFTER:\n"  . $this->phase2_explain_summary( $a['explain'] );
+			$log .= "\n";
+		}
+
+		$log .= "================================================\n";
+		return $log;
+	}
+
+	/**
+	 * Compress an EXPLAIN result set to the columns relevant to this study.
+	 */
+	private function phase2_explain_summary( $explain_rows ) {
+		if ( empty( $explain_rows ) ) {
+			return "    (no EXPLAIN rows)\n";
+		}
+
+		$out  = sprintf(
+			"    %-6s %-22s %-18s %-40s %8s %10s %s\n",
+			'id', 'select_type', 'table', 'key', 'rows', 'filtered', 'Extra'
+		);
+		foreach ( $explain_rows as $row ) {
+			$r = get_object_vars( $row );
+			$out .= sprintf(
+				"    %-6s %-22s %-18s %-40s %8s %10s %s\n",
+				$r['id']          ?? '',
+				$r['select_type'] ?? '',
+				$r['table']       ?? '',
+				$r['key']         ?? 'NULL',
+				$r['rows']        ?? '',
+				$r['filtered']    ?? '',
+				$r['Extra']       ?? ''
+			);
+		}
+		return $out;
+	}
+
+	private function phase2_median( array $nums ) {
+		sort( $nums );
+		$c = count( $nums );
+		if ( $c === 0 ) {
+			return 0.0;
+		}
+		$mid = (int) floor( $c / 2 );
+		if ( $c % 2 === 1 ) {
+			return $nums[ $mid ];
+		}
+		return ( $nums[ $mid - 1 ] + $nums[ $mid ] ) / 2;
+	}
 }


### PR DESCRIPTION
## Summary

Closes the Phase 2 checklist items in #22 with an empirical answer: **a composite `wp_postmeta(meta_key, post_id, meta_value(191))` index does not measurably help at 5k or 20k attachments on MySQL 8.0**, because the stock `wp_postmeta.post_id` index already serves the correlated EXISTS at `rows=1-2`. No plugin runtime changes — this PR adds only a benchmark harness and a documented null result.

- `tests/benchmark/LargeScaleProfilingTest::test_phase2_composite_index_comparison` — gated under `--group slow`. Captures EXPLAIN + 3-run median timing per scenario before and after creating the candidate index, then drops the index in `finally{}` plus a `register_shutdown_function` guard so the schema is always restored.
- `docs/phase-2-index-benchmarks.md` — TL;DR, methodology, raw results at 5k and 20k, per-scenario verdict, and the recommendation against putting index guidance in `README.md`. A draft README snippet is included for future use if data ever shifts; it is intentionally not applied.
- Recommendation: keep guidance in developer docs only. The harness is reusable for future contributors testing other index shapes, larger libraries, or different MySQL/MariaDB versions.

Phase 2 of #22 can be closed after this lands; Phase 3 design is in flight separately.

## Test plan

- [ ] `composer test` passes (41 tests, no plugin behavior change)
- [ ] `bin/profile.sh 5000` runs the new comparison method to completion and emits before/after EXPLAIN + timing
- [ ] `bin/profile.sh 20000` runs the new comparison method to completion (~2:35 locally)
- [ ] After either profile run, `SHOW INDEX FROM wp_postmeta` confirms the candidate index was dropped (i.e. only WordPress core indexes remain)
- [ ] Spot-check the docs file renders cleanly on GitHub
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/1fixdotio/media-search-enhanced/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
